### PR TITLE
Update `Documenter -> v1`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,9 +6,13 @@ on:
     - main
     tags:
     - '*'
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   docs:
+    if: ${{ !(github.event_name == 'pull_request') || contains(github.event.pull_request.labels.*.name, 'documentation') }}
     name: Documentation
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docscleanuo.yml
+++ b/.github/workflows/docscleanuo.yml
@@ -1,0 +1,30 @@
+name: Documentation Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  doc-preview-cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - name: Delete preview and history
+        run: |
+            git config user.name "Documenter.jl"
+            git config user.email "documenter@juliadocs.github.io"
+            git rm -rf "previews/PR$PRNUM"
+            git commit -m "delete preview"
+            git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+        env:
+            PRNUM: ${{ github.event.number }}
+
+      - name: Push changes
+        run: |
+            git push --force origin gh-pages-new:gh-pages
+            
+# Workflow copied from https://github.com/CliMA/TimeMachine.jl

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [compat]
-Documenter = "0.27"
+Documenter = "1"

--- a/docs/customdocs.jl
+++ b/docs/customdocs.jl
@@ -1,0 +1,81 @@
+module CustomDocs
+
+import Base: Docs
+import Documenter
+import Documenter: Markdown, MarkdownAST, doccat
+import Documenter.Selectors: order, matcher, runner
+
+# This is a bit of a hack to let us insert documentation blocks with custom content.
+# It means we can document Python things directly in the documentation source, and they
+# are searchable.
+#
+# It's a hack because of the `doccat` overload, requiring a special kind of "signature"
+# to embed the information we want.
+#
+# The first line is of the form "name - category", the rest is Markdown documentation.
+# For example:
+# ```@customdoc
+# foo - Function
+# Documentation for `foo`.
+# ```
+struct CustomCat{cat} end
+
+# help?> Documenter.doccat
+#   Returns the category name of the provided Object.
+doccat(::Docs.Binding, ::Type{CustomCat{cat}}) where {cat} = string(cat)
+
+abstract type CustomDocExpander <: Documenter.Expanders.ExpanderPipeline end
+
+order(::Type{CustomDocExpander}) = 20.0
+
+function matcher(::Type{CustomDocExpander}, node, page, doc)
+    return Documenter.iscode(node, "@customdoc")
+end
+
+function runner(::Type{CustomDocExpander}, node, page, doc)
+    block = node.element
+
+    header, body = split(block.code, "\n", limit=2)
+
+    docstring = Markdown.parse(body)
+
+    name, cat = split(header, "-", limit=2)
+
+    binding = Docs.Binding(Main, Symbol(strip(name)))
+
+    object = Documenter.Object(binding, CustomCat{Symbol(strip(cat))})
+
+    # source:
+    # https://github.com/JuliaDocs/Documenter.jl/blob/7d3dc2ceef39a62edf2de7081e2d3aaf9be8d7c3/src/expander_pipeline.jl#L959
+
+    # Generate a unique name to be used in anchors and links for the docstring.
+    slug = Documenter.slugify(object)
+    anchor = Documenter.anchor_add!(doc.internal.docs, object, slug, page.build)
+    docsnode = Documenter.DocsNode(anchor, object, page)
+
+    ast = convert(MarkdownAST.Node, docstring)
+    doc.user.highlightsig && Documenter.highlightsig!(ast)
+
+    # The following 'for' corresponds to the old dropheaders() function
+    for headingnode in ast.children
+        headingnode.element isa MarkdownAST.Heading || continue
+        
+        boldnode = MarkdownAST.Node(MarkdownAST.Strong())
+
+        for textnode in collect(headingnode.children)
+            push!(boldnode.children, textnode)
+        end
+
+        headingnode.element = MarkdownAST.Paragraph()
+
+        push!(headingnode.children, boldnode)
+    end
+
+    push!(docsnode.mdasts, ast)
+    # push!(docsnode.results, result)
+    push!(docsnode.metas, docstring.meta)
+
+    node.element = docsnode
+end
+
+end # module CustomDocs

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using Documenter, PythonCall, Markdown
+using Documenter, PythonCall
 
 include("customdocs.jl")
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,38 +1,11 @@
 using Documenter, PythonCall, Markdown
 
-# This is a bit of a hack to let us insert documentation blocks with custom content.
-# It means we can document Python things directly in the documentation source, and they
-# are searchable.
-#
-# It's a hack because of the `doccat` overload, requiring a special kind of "signature"
-# to embed the information we want.
-#
-# The first line is of the form "name - category", the rest is Markdown documentation.
-# For example:
-# ```@customdoc
-# foo - Function
-# Documentation for `foo`.
-# ```
-struct CustomCat{cat} end
-Documenter.Utilities.doccat(::Base.Docs.Binding, ::Type{CustomCat{cat}}) where {cat} = string(cat)
-struct CustomDocBlocks <: Documenter.Expanders.ExpanderPipeline end
-Documenter.Expanders.Selectors.order(::Type{CustomDocBlocks}) = 20.0
-Documenter.Expanders.Selectors.matcher(::Type{CustomDocBlocks}, node, page, doc) = Documenter.Expanders.iscode(node, "@customdoc")
-Documenter.Expanders.Selectors.runner(::Type{CustomDocBlocks}, x, page, doc) = begin
-    header, rest = split(x.code, "\n", limit=2)
-    docstr = Markdown.parse(rest)
-    name, cat = split(header, "-", limit=2)
-    binding = Docs.Binding(Main, Symbol(strip(name)))
-    object = Documenter.Utilities.Object(binding, CustomCat{Symbol(strip(cat))})
-    slug = Documenter.Utilities.slugify(strip(name))
-    anchor = Documenter.Anchors.add!(doc.internal.docs, object, slug, page.build)
-    node = Documenter.Documents.DocsNode(docstr, anchor, object, page)
-    page.mapping[x] = node
-end
+include("customdocs.jl")
 
 makedocs(
     sitename = "PythonCall & JuliaCall",
     modules = [PythonCall],
+    warnonly = [:missing_docs], # avoid raising error when docs are missing
     pages = [
         "Home" => "index.md",
         "The Julia module PythonCall" => [

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,5 +28,6 @@ makedocs(
 )
 
 deploydocs(
-    repo = "github.com/JuliaPy/PythonCall.jl.git",
+    repo = raw"github.com/JuliaPy/PythonCall.jl.git",
+    push_preview = true
 )


### PR DESCRIPTION
This PR aims to update the Documenter.jl version to `v1`, thus closes #359.

The `DocsNode` API changed significantly in `v1`, so we might need some help from @mortenpi to restore the previous functionality.