### PR TITLE
Add warning and hint when loading torch before juliacall

### DIFF
--- a/pysrc/juliacall/__init__.py
+++ b/pysrc/juliacall/__init__.py
@@ -53,6 +53,15 @@ def init():
     import ctypes as c
     import sys
     import subprocess
+    import warnings
+
+    # importing pytorch before juliacall sometimes causes segfaults. TODO: remove
+    if "torch" in sys.modules:
+        warnings.warn(
+            "`torch` was loaded before the juliacall. This may cause a segfault. "
+            "To avoid this, import `juliacall` *before* importing `torch`. "
+            "For updates, see https://github.com/pytorch/pytorch/issues/78829"
+        )
 
     def option(name, default=None, xkey=None, envkey=None):
         """Get an option.


### PR DESCRIPTION
Before
```sh
x@x pythoncall % python -c 'import torch; from torch.autograd import Function; import juliacall'
zsh: segmentation fault  python3 -c 
x@x pythoncall % be sad
zsh: command not found: be
```
After
```sh
x@x pythoncall % python -c 'import torch; from torch.autograd import Function; import juliacall'
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/juliacall/__init__.py:62: UserWarning: `torch` was loaded before the juliacall. This may cause a segfault. To avoid this, import `juliacall` *before* importing `torch`. For updates, see https://github.com/pytorch/pytorch/issues/78829
  warnings.warn(
zsh: segmentation fault  python3 -c 
x@x pythoncall % python -c 'import juliacall; import torch; from torch.autograd import Function'
x@x
```

Helps with https://github.com/JuliaPy/PythonCall.jl/issues/384, but doesn't solve the issue satisfactorily.