### PR TITLE
Add an example for `tname` for custom Python-to-Julia conversion rule

### DIFF
--- a/src/Convert/pyconvert.jl
+++ b/src/Convert/pyconvert.jl
@@ -23,7 +23,7 @@ Add a new conversion rule for `pyconvert`.
 ### Arguments
 
 - `tname` is a string of the form `"__module__:__qualname__"` identifying a Python type `t`,
-  such as `"builtins:dict"` and `"sympy.core.symbol:Symbol"`. This rule only applies to
+  such as `"builtins:dict"` or `"sympy.core.symbol:Symbol"`. This rule only applies to
   Python objects of this type.
 - `T` is a Julia type, such that this rule only applies when the target type intersects
   with `T`.

--- a/src/Convert/pyconvert.jl
+++ b/src/Convert/pyconvert.jl
@@ -23,7 +23,8 @@ Add a new conversion rule for `pyconvert`.
 ### Arguments
 
 - `tname` is a string of the form `"__module__:__qualname__"` identifying a Python type `t`,
-  such as `"builtins:dict"`. This rule only applies to Python objects of this type.
+  such as `"builtins:dict"` and `"sympy.core.symbol:Symbol"`. This rule only applies to
+  Python objects of this type.
 - `T` is a Julia type, such that this rule only applies when the target type intersects
   with `T`.
 - `func` is the function implementing the rule.


### PR DESCRIPTION
I ran into the same issue as https://discourse.julialang.org/t/sympy-symbol-to-symbolics-jl-num-adding-a-rule/102915 and thus thought it may be helpful to add another example to the docstring.