### PR TITLE
Add PySR integration test

### DIFF
--- a/pytest/test_all.py
+++ b/pytest/test_all.py
@@ -17,3 +17,39 @@ def test_issue_394():
     assert jl.f is f
     assert jl.y is y
     assert jl.seval("f(x)") == 4
+
+
+def test_integration_pysr():
+    "Integration tests for PySR"
+    import subprocess
+    import sys
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        subprocess.run([sys.executable, "-m", "virtualenv", tempdir], check=True)
+        # Install this package
+        subprocess.run([sys.executable, "-m", "pip", "install", "."], check=True)
+        # Install PySR with no requirement on JuliaCall
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--no-deps", "pysr"], check=True
+        )
+        # Install PySR test requirements
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "sympy",
+                "pandas",
+                "scikit_learn",
+                "click",
+                "setuptools",
+                "typing_extensions",
+                "pytest",
+                "nbval",
+            ],
+            check=True,
+        )
+        # Run PySR main test suite
+        subprocess.run([sys.executable, "-m", "pysr", "test", "main"], check=True)


### PR DESCRIPTION
Now that PySR has switched to PythonCall.jl, here is the promised integration test :)

I'm installing and running it in a separate virtualenv so as to not interfere with anything.