### PR TITLE
Ensure error message shows for missing libpython

### DIFF
--- a/src/C/context.jl
+++ b/src/C/context.jl
@@ -122,7 +122,7 @@ function init_context()
                     break
                 end
             end
-            CTX.lib_path === nothing && error("""
+            CTX.lib_path === missing && error("""
                 Could not find Python library for Python executable $(repr(CTX.exe_path)).
 
                 If you know where the library is, set environment variable 'JULIA_PYTHONCALL_LIB' to its path.


### PR DESCRIPTION
Before 

```
julia> ENV["JULIA_CONDAPKG_BACKEND"] = "Null"
"Null"

julia> using PythonCall
Precompiling PythonCall
  1 dependency successfully precompiled in 6 seconds. 22 already precompiled.
┌ Warning: Python library "/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0" could not be opened.
└ @ PythonCall.C /opt/.julia/dev/PythonCall/src/C/context.jl:118
ERROR: InitError: ArgumentError: NULL library handle
Stacktrace:
  [1] #dlsym#1
    @ ./libdl.jl:57
  [2] dlsym
    @ ./libdl.jl:56 [inlined]
  [3] init_pointers(p::PythonCall.C.CAPIPointers, lib::Ptr{Nothing})
    @ PythonCall.C /opt/.julia/dev/PythonCall/src/C/pointers.jl:282
  [4] init_pointers
    @ /opt/.julia/dev/PythonCall/src/C/pointers.jl:282 [inlined]
  [5] init_context()
    @ PythonCall.C /opt/.julia/dev/PythonCall/src/C/context.jl:138
  [6] __init__()
    @ PythonCall.C /opt/.julia/dev/PythonCall/src/C/C.jl:23
  [7] run_module_init(mod::Module, i::Int64)
    @ Base ./loading.jl:1134
  [8] register_restored_modules(sv::Core.SimpleVector, pkg::Base.PkgId, path::String)
    @ Base ./loading.jl:1122
  [9] _include_from_serialized(pkg::Base.PkgId, path::String, ocachepath::String, depmods::Vector{Any})
    @ Base ./loading.jl:1067
 [10] _require_search_from_serialized(pkg::Base.PkgId, sourcepath::String, build_id::UInt128)
    @ Base ./loading.jl:1581
 [11] _require(pkg::Base.PkgId, env::String)
    @ Base ./loading.jl:1938
 [12] __require_prelocked(uuidkey::Base.PkgId, env::String)
    @ Base ./loading.jl:1812
 [13] #invoke_in_world#3
    @ ./essentials.jl:926 [inlined]
 [14] invoke_in_world
    @ ./essentials.jl:923 [inlined]
 [15] _require_prelocked(uuidkey::Base.PkgId, env::String)
    @ Base ./loading.jl:1803
 [16] macro expansion
    @ ./loading.jl:1790 [inlined]
 [17] macro expansion
    @ ./lock.jl:267 [inlined]
 [18] __require(into::Module, mod::Symbol)
    @ Base ./loading.jl:1753
 [19] #invoke_in_world#3
    @ ./essentials.jl:926 [inlined]
 [20] invoke_in_world
    @ ./essentials.jl:923 [inlined]
 [21] require(into::Module, mod::Symbol)
    @ Base ./loading.jl:1746
during initialization of module C
```



After


```
julia> ENV["JULIA_CONDAPKG_BACKEND"] = "Null"
"Null"

julia> using PythonCall
Precompiling PythonCall
  1 dependency successfully precompiled in 6 seconds. 22 already precompiled.
┌ Warning: Python library "/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0" could not be opened.
└ @ PythonCall.C /opt/.julia/dev/PythonCall/src/C/context.jl:118
ERROR: InitError: Could not find Python library for Python executable "/usr/local/bin/python".

If you know where the library is, set environment variable 'JULIA_PYTHONCALL_LIB' to its path.

Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
```