### PR TITLE
Remove some leftover _Py

### DIFF
--- a/src/Compat/gui.jl
+++ b/src/Compat/gui.jl
@@ -130,7 +130,7 @@ function init_gui()
         pycopy!(new_event_loop_callback, g["new_event_loop_callback"])
 
         # add a hook to automatically call fix_qt_plugin_path()
-        fixqthook = Py(() -> (_Py.CONFIG.auto_fix_qt_plugin_path && fix_qt_plugin_path(); nothing))
+        fixqthook = Py(() -> (Core.CONFIG.auto_fix_qt_plugin_path && fix_qt_plugin_path(); nothing))
         pymodulehooks.add_hook("PyQt4", fixqthook)
         pymodulehooks.add_hook("PyQt5", fixqthook)
         pymodulehooks.add_hook("PySide", fixqthook)

--- a/src/Compat/pycall.jl
+++ b/src/Compat/pycall.jl
@@ -10,7 +10,7 @@ function init_pycall(PyCall::Module)
     - Set the environment variable `PYTHON` to `PythonCall.C.CTX.exe_path` and rebuild PyCall. This forces PyCall
       to use the same interpreter as PythonCall, but needs to be repeated whenever you switch Julia environment.
     """
-    @eval function _Py.Py(x::$PyCall.PyObject)
+    @eval function Core.Py(x::$PyCall.PyObject)
         C.CTX.matches_pycall::Bool || error($errmsg)
         return pynew(C.PyPtr($PyCall.pyreturn(x)))
     end

--- a/src/JlWrap/objectarray.jl
+++ b/src/JlWrap/objectarray.jl
@@ -23,7 +23,7 @@ PyObjectArray(undef::UndefInitializer, dims::Vararg{Integer,N}) where {N} = PyOb
 PyObjectArray{N}(x::AbstractArray{T,N}) where {T,N} = copyto!(PyObjectArray{N}(undef, size(x)), x)
 PyObjectArray(x::AbstractArray{T,N}) where {T,N} = PyObjectArray{N}(x)
 
-pyobjectarray_finalizer(x::PyObjectArray) = _Py.GC.enqueue_all(x.ptrs)
+pyobjectarray_finalizer(x::PyObjectArray) = GC.enqueue_all(x.ptrs)
 
 Base.IndexStyle(x::PyObjectArray) = Base.IndexStyle(x.ptrs)
 


### PR DESCRIPTION
Noticed an error during GC: `error in running finalizer: UndefVarError(var=:_Py)`. Probably due to one of these?