### PR TITLE
making it possible to use another package instead of `pickle` for serialization (e.g. `dill`)

### DIFF
--- a/src/Compat/serialization.jl
+++ b/src/Compat/serialization.jl
@@ -6,7 +6,7 @@ function serialize_py(s, x::Py)
     if pyisnull(x)
         serialize(s, nothing)
     else
-        b = pyimport("pickle").dumps(x)
+        b = pyimport(get(ENV, "JULIA_PYTHONCALL_PICKLE", "pickle")).dumps(x)
         serialize(s, pybytes_asvector(b))
     end
 end
@@ -16,7 +16,7 @@ function deserialize_py(s)
     if v === nothing
         pynew()
     else
-        pyimport("pickle").loads(pybytes(v))
+        pyimport(get(ENV, "JULIA_PYTHONCALL_PICKLE", "pickle")).loads(pybytes(v))
     end
 end
 


### PR DESCRIPTION
Looking into the documentation it looks like PythonCall uses Environment Variables for configuration.

Hence I added a simple `"JULIA_PYTHONCALL_PICKLE"` Environment Variable which defaults to `"pickle"`. This way users like me can easily use a more complete serialization system, as "pickle" cannot serialize everything (e.g. precompiled code, which is my usecase).