### PR TITLE
make python GC always run on thread 1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,15 @@ jobs:
   julia:
     name: Test (${{ matrix.os }}, julia ${{ matrix.jlversion }})
     runs-on: ${{ matrix.os }}
+    env:
+      JULIA_NUM_THREADS: ${{ matrix.jl_nthreads }}
     strategy:
       fail-fast: true
       matrix:
         arch: [x64] # x86 unsupported by MicroMamba
         os: [ubuntu-latest, windows-latest, macos-latest]
-        jlversion: ['1','1.6']
+        jlversion: ['1', '1.6']
+        jl_nthreads: ['1', '2']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Julia ${{ matrix.jlversion }}
@@ -52,11 +55,14 @@ jobs:
   python:
     name: Test (${{ matrix.os }}, python ${{ matrix.pyversion }})
     runs-on: ${{ matrix.os }}
+    env:
+      JULIA_NUM_THREADS: ${{ matrix.jl_nthreads }}
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         pyversion: ["3.x", "3.8"]
+        jl_nthreads: ['1', '2']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.pyversion }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Manifest.toml
+Manifest-*.toml
 .ipynb_checkpoints
 __pycache__
 *.egg-info

--- a/gcbench.jl
+++ b/gcbench.jl
@@ -1,0 +1,43 @@
+using PythonCall, Test
+
+function wait_for_queue_to_be_empty()
+    ret = timedwait(5) do
+        isempty(PythonCall.GC.QUEUE)
+    end
+    ret === :ok || error("QUEUE still not empty")
+end
+
+# https://github.com/JuliaCI/GCBenchmarks/blob/fc288c696381ebfdef8f002168addd0ec1b08e34/benches/serial/append/append.jl
+macro gctime(ex)
+    quote
+        local prior = PythonCall.GC.SECONDS_SPENT_IN_GC[]
+        local ret = @timed $(esc(ex))
+        Base.time_print(stdout, ret.time * 1e9, ret.gcstats.allocd, ret.gcstats.total_time, Base.gc_alloc_count(ret.gcstats); msg="Runtime")
+        println(stdout)
+        local waiting = @elapsed wait_for_queue_to_be_empty()
+        local after = PythonCall.GC.SECONDS_SPENT_IN_GC[]
+        Base.time_print(stdout, (after - prior) * 1e9; msg="Python GC time")
+        println(stdout)
+        Base.time_print(stdout, waiting * 1e9; msg="Python GC time (waiting)")
+        println(stdout)
+        ret.value
+    end
+end
+
+function append_lots(iters=100 * 1024, size=1596)
+    v = pylist()
+    for i = 1:iters
+        v.append(pylist(rand(size)))
+    end
+    return v
+end
+
+GC.enable_logging(false)
+PythonCall.GC.enable_logging(false)
+@time "Total" begin
+    @gctime append_lots()
+    @time "Next full GC" begin
+        GC.gc(true)
+        wait_for_queue_to_be_empty()
+    end
+end

--- a/pytest/test_all.py
+++ b/pytest/test_all.py
@@ -81,12 +81,26 @@ def test_julia_gc():
     # We make a bunch of python objects with no reference to them,
     # then call GC to try to finalize them.
     # We want to make sure we don't segfault.
+    # Here we can (manually) verify that the background task is running successfully,
+    # by seeing the printout "Python GC (100 items): 0.000000 seconds."
+    # We also programmatically check things are working by verifying the queue is empty.
+    # Debugging note: if you get segfaults, then run the tests with
+    # `PYTHON_JULIACALL_HANDLE_SIGNALS=yes python3 -X faulthandler -m pytest -p no:faulthandler -s --nbval --cov=pysrc ./pytest/`
+    # in order to recover a bit more information from the segfault.
     jl.seval(
         """
-        using PythonCall
+        using PythonCall, Test
+        PythonCall.GC.enable_logging()
         let
             pyobjs = map(pylist, 1:100)
+            Threads.@threads for obj in pyobjs
+                finalize(obj)
+            end
         end
         GC.gc()
+        ret = timedwait(5) do
+            isempty(PythonCall.GC.QUEUE)
+        end
+        @test ret === :ok
         """
     )

--- a/pytest/test_all.py
+++ b/pytest/test_all.py
@@ -75,3 +75,18 @@ def test_issue_433():
         """
     )
     assert out == 25
+
+def test_julia_gc():
+    from juliacall import Main as jl
+    # We make a bunch of python objects with no reference to them,
+    # then call GC to try to finalize them.
+    # We want to make sure we don't segfault.
+    jl.seval(
+        """
+        using PythonCall
+        let
+            pyobjs = map(pylist, 1:100)
+        end
+        GC.gc()
+        """
+    )

--- a/src/GC/GC.jl
+++ b/src/GC/GC.jl
@@ -104,7 +104,9 @@ function launch_gc_task()
     # ensure the task runs from thread 1
     ccall(:jl_set_task_tid, Cvoid, (Any, Cint), task, 0)
     schedule(task)
-    Base.errormonitor(task)
+    if isdefined(Base, :errormonitor)
+        Base.errormonitor(task)
+    end
     GC_TASK[] = task
     task
 end

--- a/src/GC/GC.jl
+++ b/src/GC/GC.jl
@@ -86,12 +86,7 @@ function gc_loop()
         if ENABLED[] && !isempty(QUEUE)
             unsafe_process_queue!()
             # just for testing purposes
-            lock(GC_FINISHED)
-            try
-                notify(GC_FINISHED) 
-            finally
-                unlock(GC_FINISHED)
-            end
+            Base.@lock GC_FINISHED notify(GC_FINISHED)
         end
         # wait until there is both something to process
         # and GC is `enabled`

--- a/src/GC/GC.jl
+++ b/src/GC/GC.jl
@@ -105,8 +105,10 @@ end
 function enqueue(ptr::C.PyPtr)
     # if we are on thread 1:
     f = () -> begin
-        if ptr != C.PyNULL
-            C.Py_DecRef(ptr)
+        C.with_gil(false) do
+            if ptr != C.PyNULL
+                C.Py_DecRef(ptr)
+            end
         end
     end
     # otherwise:
@@ -121,9 +123,11 @@ end
 function enqueue_all(ptrs)
     # if we are on thread 1:
     f = () -> begin
-        for ptr in ptrs
-            if ptr != C.PyNULL
-                C.Py_DecRef(ptr)
+        C.with_gil(false) do
+            for ptr in ptrs
+                if ptr != C.PyNULL
+                    C.Py_DecRef(ptr)
+                end
             end
         end
     end

--- a/src/GC/GC.jl
+++ b/src/GC/GC.jl
@@ -113,6 +113,7 @@ end
 
 function __init__()
     launch_gc_task()
+    enable() # start enabled
     nothing
 end
 

--- a/src/GC/GC.jl
+++ b/src/GC/GC.jl
@@ -21,7 +21,7 @@ const QUEUE = Channel{C.PyPtr}(Inf)
 const GC_TASK = Ref{Task}()
 
 # This we use in testing to know when our GC is running
-const GC_FINISHED = Threads.Condition(ReentrantLock())
+const GC_FINISHED = Threads.Condition()
 
 """
     PythonCall.GC.disable()

--- a/src/GC/GC.jl
+++ b/src/GC/GC.jl
@@ -26,12 +26,8 @@ const GC_FINISHED = Threads.Condition()
 """
     PythonCall.GC.disable()
 
-Disable the PythonCall garbage collector.
+Disable the PythonCall garbage collector. This should generally not be required.
 
-This means that whenever a Python object owned by Julia is finalized, it is not immediately
-freed but is instead added to a queue of objects to free later when `enable()` is called.
-
-Like most PythonCall functions, you must only call this from the main thread.
 """
 function disable()
     ENABLED[] = false
@@ -42,12 +38,8 @@ end
 """
     PythonCall.GC.enable()
 
-Re-enable the PythonCall garbage collector.
+Re-enable the PythonCall garbage collector. This should generally not be required.
 
-This frees any Python objects which were finalized while the GC was disabled, and allows
-objects finalized in the future to be freed immediately.
-
-Like most PythonCall functions, you must only call this from the main thread.
 """
 function enable()
     ENABLED[] = true

--- a/src/GC/GC.jl
+++ b/src/GC/GC.jl
@@ -12,6 +12,10 @@ using ..C: C
 # `ENABLED`: whether or not python GC is enabled, or paused to process later
 const ENABLED = Threads.Atomic{Bool}(true)
 # this event allows us to `wait` in a task until GC is re-enabled
+# we have both this and `ENABLED` since there is no `isready(::Event)`
+# for us to do a non-blocking check. Instead we must keep the event being triggered
+# in-sync with `ENABLED[]`.
+# We therefore modify both in `enable()` and `disable()` and nowhere else.
 const ENABLED_EVENT = Threads.Event()
 
 # this is the queue to process pointers for GC (`C.Py_DecRef`)

--- a/test/GC.jl
+++ b/test/GC.jl
@@ -28,12 +28,9 @@ end
         # that the ordering is correct and we can't miss the event.
         is_waiting = Threads.Atomic{Bool}(false)
         rdy = Threads.@spawn begin
-            lock(PythonCall.GC.GC_FINISHED)
-            try
+            Base.@lock PythonCall.GC.GC_FINISHED begin
                 is_waiting[] = true
                 wait(PythonCall.GC.GC_FINISHED)
-            finally
-                unlock(PythonCall.GC.GC_FINISHED)
             end
         end
         # Wait until the task starts

--- a/test/GC.jl
+++ b/test/GC.jl
@@ -1,1 +1,56 @@
-# TODO
+@testset "201: GC segfaults" begin
+    # https://github.com/JuliaPy/PythonCall.jl/issues/201
+    # This should not segfault!
+    cmd = Base.julia_cmd()
+    path = joinpath(@__DIR__, "finalize_test_script.jl")
+    p = run(`$cmd -t2 --project $path`)
+    @test p.exitcode == 0
+end
+
+@testset "GC.enable() and GC.disable()" begin
+    PythonCall.GC.disable()
+    try
+        # Put some stuff in the GC queue
+        let
+            pyobjs = map(pylist, 1:100)
+            foreach(PythonCall.Core.py_finalizer, pyobjs)
+        end
+        # Since GC is disabled, we should have built up entries in the queue
+        # (there is no race since we push to the queue eagerly)
+        @test !isempty(PythonCall.GC.QUEUE)
+        # now, setup a task so we can know once GC has triggered.
+        # We start waiting *before* enabling GC, so we know we'll catch
+        # the notification that GC finishes
+        # We also don't enable GC until we get confirmation via `is_waiting[]`.
+        # At this point we have acquired the lock for `PythonCall.GC.GC_FINISHED`.
+        # We won't relinquish it until the next line where we `wait`,
+        # at which point the GC can trigger it. Therefore we should be certain
+        # that the ordering is correct and we can't miss the event.
+        is_waiting = Threads.Atomic{Bool}(false)
+        rdy = Threads.@spawn begin
+            lock(PythonCall.GC.GC_FINISHED)
+            try
+                is_waiting[] = true
+                wait(PythonCall.GC.GC_FINISHED)
+            finally
+                unlock(PythonCall.GC.GC_FINISHED)
+            end
+        end
+        # Wait until the task starts
+        ret = timedwait(5) do
+            istaskstarted(rdy) && is_waiting[]
+        end
+        @test ret == :ok
+        # Now, re-enable GC
+        PythonCall.GC.enable()
+        # Wait for GC to run
+        wait(rdy)
+        # There should be nothing left in the queue, since we fully process it.
+        @test isempty(PythonCall.GC.QUEUE)
+    finally
+        # Make sure we re-enable GC regardless of whether our tests pass
+        PythonCall.GC.enable()
+    end
+end
+
+@test_throws ConcurrencyViolationError("PythonCall GC task already running!") PythonCall.GC.launch_gc_task()

--- a/test/finalize_test_script.jl
+++ b/test/finalize_test_script.jl
@@ -4,6 +4,6 @@ using PythonCall
 let
     pyobjs = map(pylist, 1:100)
     Threads.@threads for obj in pyobjs
-        PythonCall.Core.py_finalizer(obj)
+        finalize(obj)
     end
 end

--- a/test/finalize_test_script.jl
+++ b/test/finalize_test_script.jl
@@ -1,0 +1,9 @@
+using PythonCall
+
+# This would consistently segfault pre-GC-thread-safety
+let
+    pyobjs = map(pylist, 1:100)
+    Threads.@threads for obj in pyobjs
+        PythonCall.Core.py_finalizer(obj)
+    end
+end


### PR DESCRIPTION
closes #201 

Here, we make the GC queue threadsafe (by using a Channel), so we can safely enqueue objects from any thread. Then we process it from a dedicated task which runs on thread 1, which is the thread in which we have initalized the correct state in the python runtime (https://docs.python.org/3/c-api/init.html#non-python-created-threads). We continue to respect `GC.enable()` and `GC.disable()` but it should not be very useful anymore since it is no longer required to disable GC in threaded regions. (However users must still only interact with the python runtime via thread 1, unless they setup the right state).

This was a bit complicated to test unfortunately, but if I have reasoned correctly (if!) there should be no races in the testing.

Notes:

- I'm not sure if we should skip the task creation during `__init__` during precompilation (will it hang precompilation? is it fine to not GC then)?
- I'm not sure if this will be less performant in the single-threaded case, if we are not eagerly freeing but instead deferring to a separate task to do so
- I haven't used `Threads.Condition` or `Threads.Event` before, hopefully I got it right