### PR TITLE
Require a compatible openssl version

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,6 +1,9 @@
 [deps.libstdcxx-ng]
 version = "<=julia"
 
+[deps.openssl]
+version = "<=julia"
+
 [deps.python]
 build = "**cpython**"
 version = ">=3.8,<4"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ UnsafePointers = "e17b2a0c-0bdf-430a-bd0c-3a23cae4ff39"
 
 [compat]
 Aqua = "0 - 999"
-CondaPkg = "0.2.21"
+CondaPkg = "0.2.23"
 Dates = "1"
 Libdl = "1"
 MacroTools = "0.5"


### PR DESCRIPTION
Resolves #519 (at least for the specific case of OpenSSL)
Requires https://github.com/JuliaPy/CondaPkg.jl/pull/140

Similar to how ibstdcpp-ng is handled, this PR communicated to `CondaPkg.jl` that we need a version of openssl that is compatible with one version potentially loaded via `OpenSSL_jll`

