### PR TITLE
Update GIL.jl lock's documentation (possible mistake?)

### DIFF
--- a/src/GIL/GIL.jl
+++ b/src/GIL/GIL.jl
@@ -12,7 +12,7 @@ using ..C: C
 """
     lock(f)
 
-Unlock the GIL, compute `f()`, unlock the GIL, then return the result of `f()`.
+Lock the GIL, compute `f()`, unlock the GIL, then return the result of `f()`.
 
 Use this to run Python code from threads that do not currently hold the GIL, such as new
 threads. Since the main Julia thread holds the GIL by default, you will need to
@@ -32,7 +32,7 @@ end
 """
     @lock expr
 
-Unlock the GIL, compute `expr`, unlock the GIL, then return the result of `expr`.
+Lock the GIL, compute `expr`, unlock the GIL, then return the result of `expr`.
 
 Use this to run Python code from threads that do not currently hold the GIL, such as new
 threads. Since the main Julia thread holds the GIL by default, you will need to


### PR DESCRIPTION
I think "unlock" is a typo and should be "lock". 
Hence, a GIL lock "locks, computes, unlocks" rather than "unlocks, computes, unlocks" unless there is something I'm missing. 

Nice work on the GIL by the way !