### PR TITLE
Fix a typo that broke finalizers

### DIFF
--- a/src/GC/GC.jl
+++ b/src/GC/GC.jl
@@ -103,7 +103,7 @@ function enqueue(ptr::C.PyPtr)
 end
 
 function enqueue_all(ptrs)
-    if any(!=(C.PYNULL), ptrs) && C.CTX.is_initialized
+    if any(!=(C.PyNULL), ptrs) && C.CTX.is_initialized
         if C.PyGILState_Check() == 1
             for ptr in ptrs
                 if ptr != C.PyNULL


### PR DESCRIPTION
Caused finalizers to crash, which doesn't bring down Julia. Not the first time this is happened - guess we need to figure out how to catch this in tests!