### PR TITLE
fix PyNULL typo

### DIFF
--- a/src/GC/GC.jl
+++ b/src/GC/GC.jl
@@ -103,7 +103,7 @@ function enqueue(ptr::C.PyPtr)
 end
 
 function enqueue_all(ptrs)
-    if any(!=(C.PYNULL), ptrs) && C.CTX.is_initialized
+    if any(!=(C.PyNULL), ptrs) && C.CTX.is_initialized
         if C.PyGILState_Check() == 1
             for ptr in ptrs
                 if ptr != C.PyNULL

--- a/test/JlWrap.jl
+++ b/test/JlWrap.jl
@@ -577,4 +577,13 @@ end
         @test pyeq(Bool, x.count(nothing), 0)
         @test pyeq(Bool, x.count("2"), 0)
     end
+
+    @testset "PyObjectArray" begin
+        # https://github.com/JuliaPy/PythonCall.jl/issues/543
+        # Here we check the finalizer does not error
+        # We must not reuse `arr` in this code once we finalize it!
+        let arr = PyObjectArray([pylist([1]), pylist([2])])
+            PythonCall.JlWrap.pyobjectarray_finalizer(arr)
+        end
+    end
 end

--- a/test/JlWrap.jl
+++ b/test/JlWrap.jl
@@ -582,8 +582,8 @@ end
         # https://github.com/JuliaPy/PythonCall.jl/issues/543
         # Here we check the finalizer does not error
         # We must not reuse `arr` in this code once we finalize it!
-        let arr = PyObjectArray([pylist([1]), pylist([2])])
-            PythonCall.JlWrap.pyobjectarray_finalizer(arr)
+        let arr = PyObjectArray([1, 2, 3])
+            finalize(arr)
         end
     end
 end


### PR DESCRIPTION
closes https://github.com/JuliaPy/PythonCall.jl/issues/543, closes https://github.com/JuliaPy/PythonCall.jl/pull/541

I added a test that would catch the issue:
```julia
julia> let arr = PyObjectArray([pylist([1]), pylist([2])])
                   PythonCall.JlWrap.pyobjectarray_finalizer(arr)
               end
ERROR: UndefVarError: `PYNULL` not defined
Stacktrace:
 [1] enqueue_all(ptrs::Vector{Ptr{PythonCall.C.PyObject}})
   @ PythonCall.GC ~/PythonCall.jl/src/GC/GC.jl:106
 [2] pyobjectarray_finalizer(x::PyObjectVector)
   @ PythonCall.JlWrap ~/PythonCall.jl/src/JlWrap/objectarray.jl:30
 [3] top-level scope
   @ REPL[17]:2
```