### PR TITLE
fix: patch changed behavior of `setproperty!` for modules

### DIFF
--- a/src/JlWrap/any.jl
+++ b/src/JlWrap/any.jl
@@ -26,6 +26,10 @@ function pyjlany_setattr(self, k_::Py, v_::Py)
     k = Symbol(pyjl_attr_py2jl(pyconvert(String, k_)))
     pydel!(k_)
     v = pyconvert(Any, v_)
+    if VERSION >= v"1.11.0-" && self isa Module && !isdefined(self, k)
+        # Fix for https://github.com/JuliaLang/julia/pull/54678
+        Base.Core.eval(self, Expr(:global, k))
+    end
     setproperty!(self, k, v)
     Py(nothing)
 end


### PR DESCRIPTION
This fixes the breaking change introduced by Julia 1.11: https://github.com/JuliaLang/julia/pull/54678. See issue #582 for discussion.

The fix is pretty simple - we just automatically call `global` on variables that are undefined. This means that the syntax

```python
from juliacall import Main as jl

jl.x = 1
```

will continue to function.

@cjdoris could you please take a look and merge? Since Julia 1.11 is out now I think we should get this fix in relatively quickly since a lot of the docs and tutorials rely on this behavior working.