### PR TITLE
PyList: fix pushfirst! for Julia 1.11, by adding prepend!

### DIFF
--- a/src/Wrap/PyList.jl
+++ b/src/Wrap/PyList.jl
@@ -61,6 +61,13 @@ function Base.append!(x::PyList, vs)
     return x
 end
 
+function Base.prepend!(x::PyList, vs)
+    for v in reverse(vs)
+        pushfirst!(x, v)
+    end
+    return x
+end
+
 function Base.push!(x::PyList, v1, v2, vs...)
     push!(x, v1)
     push!(x, v2, vs...)

--- a/test/Wrap.jl
+++ b/test/Wrap.jl
@@ -381,6 +381,13 @@ end
         @test_throws Exception append!(t, [nothing, missing])
         @test t == [1, 2, 3, 4, 5, 6]
     end
+    @testset "prepend!" begin
+        t = copy(z)
+        @test prepend!(t, [-3, -2, -1]) === t
+        @test t == [-3, -2, -1, 1, 2, 3]
+        @test_throws Exception append!(t, [nothing, missing])
+        @test t == [-3, -2, -1, 1, 2, 3]
+    end
     @testset "pop!" begin
         t = copy(z)
         @test pop!(t) == 3


### PR DESCRIPTION
Julia 1.11 handles pushfirst! with multiple args differently and fails if no prepend! is defined.
This PR defines the appropriate prepend! method and adds respective tests.