### PR TITLE
Add `elsize` method for PyArray

### DIFF
--- a/docs/src/releasenotes.md
+++ b/docs/src/releasenotes.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Added `PYTHON_JULIACALL_HEAP_SIZE_HINT` option to configure initial Julia heap size.
+* `Base.elsize` now defined for `PyArray`.
 
 ## 0.9.24 (2025-01-22)
 * Bug fixes.

--- a/src/Wrap/PyArray.jl
+++ b/src/Wrap/PyArray.jl
@@ -637,6 +637,8 @@ Base.IndexStyle(::Type{PyArray{T,N,M,L,R}}) where {T,N,M,L,R} =
 
 Base.unsafe_convert(::Type{Ptr{T}}, x::PyArray{T,N,M,L,T}) where {T,N,M,L} = x.ptr
 
+Base.elsize(::Type{PyArray{T,N,M,L,T}}) where {T,N,M,L} = sizeof(T)
+
 Base.strides(x::PyArray{T,N,M,L,R}) where {T,N,M,L,R} =
     if all(mod.(x.strides, sizeof(R)) .== 0)
         div.(x.strides, sizeof(R))

--- a/test/Wrap.jl
+++ b/test/Wrap.jl
@@ -26,6 +26,13 @@
         @test strides(y) === (1,)
         @test strides(z) === (1,)
     end
+    @testset "elsize" begin
+        @test Base.elsize(y) === sizeof(Cint)
+        @test Base.elsize(z) === sizeof(Cint)
+        @test Base.elsize(PyArray{Cint,1,true,true,Cint}) === sizeof(Cint)
+        @test Base.elsize(PyArray{Cint,1,false,false,Cint}) === sizeof(Cint)
+        @test_throws Exception elsize(PyArray{Cint,1,true,false,Cchar})
+    end
     @testset "getindex" begin
         @test_throws BoundsError y[0]
         @test y[1] == 1


### PR DESCRIPTION
Fixes #579 