### PR TITLE
fix crash julia 1.12 beta 4:  jl_init_with_image_file

### DIFF
--- a/pysrc/juliacall/__init__.py
+++ b/pysrc/juliacall/__init__.py
@@ -193,7 +193,10 @@ def init():
     try:
         jl_init = lib.jl_init_with_image__threading
     except AttributeError:
-        jl_init = lib.jl_init_with_image
+        try:
+            jl_init = lib.jl_init_with_image
+        except AttributeError:
+            jl_init = lib.jl_init_with_image_file
     jl_init.argtypes = [c.c_char_p, c.c_char_p]
     jl_init.restype = None
     jl_init(


### PR DESCRIPTION
julia 1.12beta4 does not expose `jl_init_with_image` anymore. 
Falling back to `jl_init_with_image_file`, which works fine.
```
nm ~/.julia/juliaup/julia-1.12.0-beta4+0.x64.linux.gnu/lib/libjulia.so | grep jl_init_with_image
0000000000013b99 T jl_init_with_image_file
0000000000020ee8 b jl_init_with_image_file_addr
0000000000013ba5 T jl_init_with_image_handle
0000000000020ee0 b jl_init_with_image_handle_addr
```