### PR TITLE
docs: Code loading order

### DIFF
--- a/docs/src/pythoncall.md
+++ b/docs/src/pythoncall.md
@@ -308,6 +308,19 @@ To add dependencies to a Julia package, just ensure the package project is activ
 
 See the [CondaPkg.jl](https://github.com/JuliaPy/CondaPkg.jl) documentation.
 
+!!! note
+    If running from a script, make sure that [CondaPkg.jl](https://github.com/JuliaPy/CondaPkg.jl) is used before [PythonCall.jl](https://github.com/JuliaPy/PythonCall.jl) to ensure proper loading of Python packages in your path. E.g.,
+
+    ```julia
+    using CondaPkg
+
+    CondaPkg.add("numpy")
+
+    using PythonCall
+
+    np = pyimport("numpy")
+    ```
+
 ## Writing packages which depend on PythonCall
 
 ### Example


### PR DESCRIPTION
Added a note to help avoid the code loading edge case hit in https://github.com/JuliaPy/CondaPkg.jl/issues/188, e.g.,

```julia
using PythonCall
using CondaPkg
CondaPkg.add("numpy")
np = pyimport("numpy")
```

can fail on some platforms, while

```julia
using CondaPkg
CondaPkg.add("numpy")
using PythonCall
np = pyimport("numpy")
```

works as intended.