### PR TITLE
Improve GitHub workflow job names for better clarity

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tests:
-    name: Test (${{ matrix.os }}-${{ matrix.arch }}, julia ${{ matrix.jlversion }})
+    name: Test Julia (${{ matrix.jlversion }}, ${{ matrix.os }}-${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   julia:
-    name: Test (${{ matrix.os }}, julia ${{ matrix.jlversion }})
+    name: Test Julia (${{ matrix.jlversion }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -50,13 +50,13 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   python:
-    name: Test (${{ matrix.os }}, python ${{ matrix.pyversion }})
+    name: Test Python (${{ matrix.pyversion }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        pyversion: [">=3.8", "3.8"]
+        pyversion: ["3", "3.8"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR improves the clarity of GitHub Actions job names by:

- Changing Julia job names from Test (os, julia version) to Test Julia (version, os)
- Changing Python job names from Test (os, python version) to Test Python (version, os)
- Simplifying Python version matrix from >=3.8 to 3 for cleaner job names
- Updating nightly test job names similarly

**Before:**
- Test (ubuntu-latest, julia 1.9)
- Test (ubuntu-latest, python >=3.8)

**After:**
- Test Julia (1.9, ubuntu-latest)
- Test Python (3, ubuntu-latest)

This makes it much easier to quickly identify which language and version is being tested when looking at the GitHub Actions dashboard.