### PR TITLE
Add PySide6 support to gui.jl

### DIFF
--- a/test/Compat.jl
+++ b/test/Compat.jl
@@ -5,7 +5,7 @@
         @test PythonCall.fix_qt_plugin_path() === false
     end
     @testset "event_loop_on/off" begin
-        for g in [:pyqt4, :pyqt5, :pyside, :pyside2, :gtk, :gtk3, :wx]
+        for g in [:pyqt4, :pyqt5, :pyside, :pyside2, :pyside6, :gtk, :gtk3, :wx]
             # TODO: actually test the various GUIs somehow?
             @show g
             @test_throws PyException PythonCall.event_loop_on(g)


### PR DESCRIPTION
This PR adds PySide6 support to the GUI compatibility layer.

## Changes Made

- **Updated `fix_qt_plugin_path() function** to support both Qt5 and Qt6 configurations:
  - Added support for qt6.conf files used by PySide6 (in addition to existing qt.conf support)
  - For Qt6, reads the Libraries entry instead of Prefix 
  - Sets QT_PLUGIN_PATH to {libraries}/qt6/plugins for PySide6 compatibility
  - Maintains backward compatibility with existing Qt5 frameworks

- **Added PySide6 to event loop callback** by including it in the supported GUI frameworks list and adding the import for PySide6.QtCore

- **Added PySide6 module hook** to automatically call `fix_qt_plugin_path() when PySide6 is imported

- **Updated documentation** to include PySide6 in all relevant docstrings and parameter descriptions

## Technical Details

The key insight from the issue discussion is that Qt6 uses a different configuration file format:
- Qt5: Uses qt.conf with Prefix entry, plugins at {prefix}/plugins
- Qt6: Uses qt6.conf with Libraries entry, plugins at {libraries}/qt6/plugins

The updated function checks for qt6.conf first, then falls back to qt.conf for backward compatibility.

## Testing

This change is designed to be backward-compatible and follows the exact approach suggested by @cjdoris in the issue comments. The implementation handles the platform-dependent path differences by using the Libraries entry from qt6.conf as recommended.

Fixes #632