### PR TITLE
Remove dead code supporting old versions of Julia/Python

### DIFF
--- a/src/C/context.jl
+++ b/src/C/context.jl
@@ -188,12 +188,8 @@ function init_context()
             Py_InitializeEx(0)
             atexit() do
                 CTX.is_initialized = false
-                if CTX.version === missing || CTX.version < v"3.6"
-                    Py_Finalize()
-                else
-                    if Py_FinalizeEx() == -1
-                        @warn "Py_FinalizeEx() error"
-                    end
+                if Py_FinalizeEx() == -1
+                    @warn "Py_FinalizeEx() error"
                 end
             end
         end
@@ -223,8 +219,8 @@ function init_context()
         error("Cannot parse version from version string: $(repr(verstr))")
     end
     CTX.version = VersionNumber(vermatch.match)
-    v"3.5" ≤ CTX.version < v"4" || error(
-        "Only Python 3.5+ is supported, this is Python $(CTX.version) at $(CTX.exe_path===missing ? "unknown location" : CTX.exe_path).",
+    v"3.9" ≤ CTX.version < v"4" || error(
+        "Only Python 3.9+ is supported, this is Python $(CTX.version) at $(CTX.exe_path===missing ? "unknown location" : CTX.exe_path).",
     )
 
     @debug "Initialized PythonCall.jl" CTX.is_embedded CTX.is_initialized CTX.exe_path CTX.lib_path CTX.lib_ptr CTX.pyprogname CTX.pyhome CTX.version

--- a/src/C/pointers.jl
+++ b/src/C/pointers.jl
@@ -2,8 +2,7 @@ const CAPI_FUNC_SIGS = Dict{Symbol,Pair{Tuple,Type}}(
     # INITIALIZE
     :Py_Initialize => () => Cvoid,
     :Py_InitializeEx => (Cint,) => Cvoid,
-    :Py_Finalize => () => Cvoid,
-    :Py_FinalizeEx => () => Cint, # 3.6+
+    :Py_FinalizeEx => () => Cint,
     :Py_AtExit => (Ptr{Cvoid},) => Cint,
     :Py_IsInitialized => () => Cint,
     :Py_SetPythonHome => (Ptr{Cwchar_t},) => Cvoid,
@@ -283,11 +282,8 @@ const POINTERS = CAPIPointers()
 
 @eval init_pointers(p::CAPIPointers = POINTERS, lib::Ptr = CTX.lib_ptr) = begin
     $([
-        if name == :Py_FinalizeEx
-            :(p.$name = dlsym_e(lib, $(QuoteNode(name))))
-        else
-            :(p.$name = dlsym(lib, $(QuoteNode(name))))
-        end for name in CAPI_FUNCS
+        :(p.$name = dlsym(lib, $(QuoteNode(name))))
+        for name in CAPI_FUNCS
     ]...)
     $(
         [


### PR DESCRIPTION
This PR removes dead code that was supporting old versions of Julia and Python:

**Changes:**
- Remove fallback to Py_Finalize() for Python < 3.6, always use Py_FinalizeEx()
- Update minimum Python version check from 3.5+ to 3.9+ (aligns with recent version bump)
- Remove Py_Finalize function signature, keeping only Py_FinalizeEx
- Simplify pointer initialization by removing conditional logic
- Remove Julia version check for stacktrace formatting (< 1.6.0), keep only modern formatting

**Files changed:**
- src/C/context.jl: Simplified finalization and version checking
- src/C/pointers.jl: Removed legacy function signatures  
- src/Core/err.jl: Removed legacy stacktrace formatting

Net reduction of 18 lines, making the codebase cleaner by removing compatibility shims that are no longer needed.