### PR TITLE
build(deps): add libstdcxx pin, bump CondaPkg

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,3 +1,6 @@
+[deps.libstdcxx]
+version = "<=julia"
+
 [deps.libstdcxx-ng]
 version = "<=julia"
 

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ UnsafePointers = "e17b2a0c-0bdf-430a-bd0c-3a23cae4ff39"
 
 [compat]
 Aqua = "0 - 999"
-CondaPkg = "0.2.23"
+CondaPkg = "0.2.30"
 Dates = "1"
 Libdl = "1"
 MacroTools = "0.5"

--- a/docs/src/releasenotes.md
+++ b/docs/src/releasenotes.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Internal: Use heap-allocated types (PyType_FromSpec) to improve ABI compatibility.
 * Minimum supported Python version is now 3.9.
+* Better compatibility with libstdc++.
 
 ## 0.9.26 (2025-07-15)
 * Added PySide6 support to the GUI compatibility layer.


### PR DESCRIPTION
Add libstdcxx to CondaPkg.toml with version "<=julia" to improve libstdc++ compatibility with the Julia toolchain. Bump CondaPkg compat to 0.2.30 to leverage related fixes. Update release notes to reflect the improved compatibility.