### PR TITLE
Remove `Core` reference from `Compat/pycall.jl`

### DIFF
--- a/src/Compat/pycall.jl
+++ b/src/Compat/pycall.jl
@@ -10,7 +10,7 @@ function init_pycall(PyCall::Module)
     - Set the environment variable `PYTHON` to `PythonCall.C.CTX.exe_path` and rebuild PyCall. This forces PyCall
       to use the same interpreter as PythonCall, but needs to be repeated whenever you switch Julia environment.
     """
-    @eval function Core.Py(x::$PyCall.PyObject)
+    @eval function Py(x::$PyCall.PyObject)
         C.CTX.matches_pycall::Bool || error($errmsg)
         return pynew(C.PyPtr($PyCall.pyreturn(x)))
     end


### PR DESCRIPTION
Fixes #657.