### PR TITLE
feat(exe): add support for @venv and relative paths in JULIA_PYTHONCALL_EXE

### DIFF
--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -1,6 +1,6 @@
 # FAQ & Troubleshooting
 
-## Can I use PythonCall and PyCall together?
+## [Can I use PythonCall and PyCall together?](@id faq-pycall)
 
 Yes, you can use both PyCall and PythonCall in the same Julia session. This is platform-dependent:
 - On most systems the Python interpreter used by PythonCall and PyCall must be the same (see below).

--- a/docs/src/pythoncall.md
+++ b/docs/src/pythoncall.md
@@ -240,6 +240,7 @@ to your current Julia project containing Python and any required Python packages
 ENV["JULIA_CONDAPKG_BACKEND"] = "Null"
 ENV["JULIA_PYTHONCALL_EXE"] = "/path/to/python"  # optional
 ENV["JULIA_PYTHONCALL_EXE"] = "@PyCall"  # optional
+ENV["JULIA_PYTHONCALL_EXE"] = "@venv" # optional
 ```
 
 By setting the CondaPkg backend to Null, it will never install any Conda packages. In this
@@ -247,10 +248,13 @@ case, PythonCall will use whichever Python is currently installed and in your `P
 must have already installed any Python packages that you need.
 
 If `python` is not in your `PATH`, you will also need to set `JULIA_PYTHONCALL_EXE` to its
-path.
+path. Relative paths are resolved relative to the current active project.
 
 If you also use PyCall, you can set `JULIA_PYTHONCALL_EXE=@PyCall` to use the same Python
-interpreter.
+interpreter. [See here](@ref faq-pycall).
+
+If you have a Python virtual environment at `.venv` in your current active project, you
+can set `JULIA_PYTHONCALL_EXE=@venv` to use it.
 
 #### If you already have a Conda environment
 

--- a/docs/src/releasenotes.md
+++ b/docs/src/releasenotes.md
@@ -5,6 +5,8 @@
 * Added `pyconvert` rules for NumpyDates types.
 * Added `PyArray` support for NumPy arrays of `datetime64` and `timedelta64`.
 * Added `juliacall.ArrayValue` support for Julia arrays of `InlineDateTime64` and `InlineTimeDelta64`.
+* If `JULIA_PYTHONCALL_EXE` is a relative path, it is now considered relative to the active project.
+* Added option `JULIA_PYTHONCALL_EXE=@venv` to use a Python virtual environment relative to the active project.
 * Bug fixes.
 * Internal: switch from Requires.jl to package extensions.
 


### PR DESCRIPTION
Add new option `@venv` to use a Python virtual environment located at `.venv` in the active project directory. Relative paths for `JULIA_PYTHONCALL_EXE` are now resolved relative to the active project. Includes documentation updates and release notes.

Closes #668.