### PR TITLE
Relax conversions to python

### DIFF
--- a/docs/src/conversion-to-python.md
+++ b/docs/src/conversion-to-python.md
@@ -12,17 +12,20 @@ From Python, this occurs when converting the return value of a Julia function.
 | From                                                                | To                                                      |
 | :------------------------------------------------------------------ | :------------------------------------------------------ |
 | Any Python object type (`Py`, `PyList`, etc.)                       | itself                                                  |
-| `Nothing`, `Missing`                                                | `None`                                                  |
+| `Nothing`                                                           | `None`                                                  |
 | `Bool`                                                              | `bool`                                                  |
-| Standard integer (`IntXX`, `UIntXX`, `BigInt`)                      | `int`                                                   |
-| Standard rational (`Rational{T}`, `T` a standard integer)           | `fractions.Fraction`                                    |
-| Standard float (`FloatXX`)                                          | `float`                                                 |
-| Standard complex (`Complex{T}`, `T` a standard float)               | `complex`                                               |
-| Standard string/char (`String` and `SubString{String}`, `Char`)     | `str`                                                   |
-| `Tuple`                                                             | `tuple`                                                 |
-| Standard integer range (`AbstractRange{T}`, `T` a standard integer) | `range`                                                 |
-| `Date`, `Time`, `DateTime` (from `Dates`)                           | `date`, `time`, `datetime` (from `datetime`)            |
-| `Second`, `Millisecond`, `Microsecond`, `Nanosecond` (from `Dates`) | `timedelta` (from `datetime`)                           |
+| `Integer`                                                           | `int`                                                   |
+| `Rational{<:Integer}`                                               | `fractions.Fraction`                                    |
+| `Float64`, `Float32`, `Float16`                                     | `float`                                                 |
+| `Complex{Float64}`, `Complex{Float32}`, `Complex{Float16}`          | `complex`                                               |
+| `AbstractString`, `AbstractChar`                                    | `str`                                                   |
+| `Base.CodeUnits{UInt8}` (e.g. `b"example"`)                         | `bytes`                                                 |
+| `Tuple`, `Pair`                                                     | `tuple`                                                 |
+| `AbstractRange{<:Integer}`                                          | `range`                                                 |
+| `Dates.Date`                                                        | `datetime.date`                                         |
+| `Dates.Time`                                                        | `datetime.time`                                         |
+| `Dates.DateTime`                                                    | `datetime.datetime`                                     |
+| `Dates.Second`, `Dates.Millisecond`, `Dates.Microsecond`, `Dates.Nanosecond` | `datetime.timedelta`                           |
 | `Number`                                                            | `juliacall.NumberValue`, `juliacall.ComplexValue`, etc. |
 | `AbstractArray`                                                     | `juliacall.ArrayValue`, `juliacall.VectorValue`         |
 | `AbstractDict`                                                      | `juliacall.DictValue`                                   |

--- a/docs/src/releasenotes.md
+++ b/docs/src/releasenotes.md
@@ -8,6 +8,8 @@
 * If `JULIA_PYTHONCALL_EXE` is a relative path, it is now considered relative to the active project.
 * Added option `JULIA_PYTHONCALL_EXE=@venv` to use a Python virtual environment relative to the active project.
 * Added `PYTHON_JULIACALL_EXE` and `PYTHON_JULIACALL_PROJECT` for specifying the Julia binary and project to override JuliaPkg.
+* Adds methods `Py(::AbstractString)`, `Py(::AbstractChar)` (previously only builtin string and char types were allowed).
+* Adds methods `Py(::Integer)`, `Py(::Rational{<:Integer})`, `Py(::AbstractRange{<:Integer})` (previously only builtin integer types were allowed).
 * Bug fixes.
 * Internal: switch from Requires.jl to package extensions.
 

--- a/src/Core/Py.jl
+++ b/src/Core/Py.jl
@@ -122,25 +122,16 @@ end
 Py(x::Py) = x
 Py(x::Nothing) = pybuiltins.None
 Py(x::Bool) = x ? pybuiltins.True : pybuiltins.False
-Py(x::Union{String,SubString{String},Char}) = pystr(x)
+Py(x::Union{AbstractString,AbstractChar}) = pystr(x)
 Py(x::Base.CodeUnits{UInt8,String}) = pybytes(x)
 Py(x::Base.CodeUnits{UInt8,SubString{String}}) = pybytes(x)
 Py(x::Tuple) = pytuple_fromiter(x)
 Py(x::Pair) = pytuple_fromiter(x)
-Py(x::Union{Int8,Int16,Int32,Int64,Int128,UInt8,UInt16,UInt32,UInt64,UInt128,BigInt}) =
-    pyint(x)
-Py(
-    x::Rational{
-        <:Union{Int8,Int16,Int32,Int64,Int128,UInt8,UInt16,UInt32,UInt64,UInt128,BigInt},
-    },
-) = pyfraction(x)
+Py(x::Integer) = pyint(x)
+Py(x::Rational{<:Integer}) = pyfraction(x)
 Py(x::Union{Float16,Float32,Float64}) = pyfloat(x)
-Py(x::Complex{<:Union{Float16,Float32,Float64}}) = pycomplex(x)
-Py(
-    x::AbstractRange{
-        <:Union{Int8,Int16,Int32,Int64,Int128,UInt8,UInt16,UInt32,UInt64,UInt128,BigInt},
-    },
-) = pyrange_fromrange(x)
+Py(x::Union{Complex{Float16},Complex{Float32},Complex{Float64}}) = pycomplex(x)
+Py(x::AbstractRange{<:Integer}) = pyrange_fromrange(x)
 Py(x::Date) = pydate(x)
 Py(x::Time) = pytime(x)
 Py(x::DateTime) = pydatetime(x)

--- a/src/Core/builtins.jl
+++ b/src/Core/builtins.jl
@@ -592,6 +592,8 @@ pystr(x) = pynew(errcheck(@autopy x C.PyObject_Str(x_)))
 pystr(x::String) = pystr_fromUTF8(x)
 pystr(x::SubString{String}) = pystr_fromUTF8(x)
 pystr(x::Char) = pystr(string(x))
+pystr(x::AbstractString) = pystr(convert(String, x)::String)
+pystr(x::AbstractChar) = pystr(convert(Char, x)::Char)
 pystr(::Type{String}, x) = (s = pystr(x); ans = pystr_asstring(s); pydel!(s); ans)
 
 pystr_asUTF8bytes(x::Py) = pynew(errcheck(C.PyUnicode_AsUTF8String(x)))


### PR DESCRIPTION
Allow any string or integer to be converted to python

Specifically this adds methods `Py(::AbstractString)`, `Py(::AbstractChar)`, `Py(::Integer)`, `Py(::Rational{<:Integer})`, `Py(::AbstractRange{<:Integer})` whereas previously we only allowed the builtin Julia string, char and integer types.

Fixes #608 