### PR TITLE
avoid precompile cache miss from check-bounds option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Bug fix: avoid precompilation cache miss when `check_bounds` option set.
+
 ## 0.9.35 (2026-06-08)
 * Add option `lib` to JuliaCall. Setting this will skip the discovery subprocess.
 * Add support for using a system image in `juliacall` that has `PythonCall` baked in.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 requires-python = ">=3.10, <4"
-dependencies = ["juliapkg >=0.1.24, <0.2"]
+dependencies = ["juliapkg >=0.1.26, <0.2"]
 
 [dependency-groups]
 dev = [

--- a/pysrc/juliacall/__init__.py
+++ b/pysrc/juliacall/__init__.py
@@ -198,6 +198,18 @@ def init():
         # `exepath` and `project` are set by the user.
         import juliapkg
 
+        # Explicitly resolve so we can pass through julia_args. This ensures that any
+        # precompilation done by juliapkg matches how we launch julia, avoiding
+        # cache misses.
+        julia_args = [
+            "--" + opt[4:].replace("_", "-") + "=" + CONFIG[opt]
+            for opt in [
+                "opt_check_bounds",
+            ]
+            if CONFIG[opt] is not None
+        ]
+        juliapkg.resolve(julia_args=julia_args)
+
         # Find the Julia executable and project
         CONFIG['exepath'] = exepath = juliapkg.executable()
         CONFIG['project'] = project = juliapkg.project()


### PR DESCRIPTION
Fixes https://github.com/JuliaPy/pyjuliapkg/issues/92

Does so by passing precompile-relevant julia args into `juliapkg.resolve()` so that it precompiles with the same args as juliacall uses.