### PR TITLE
skip event_loop_on test with pyside6 on mac

### DIFF
--- a/test/Compat.jl
+++ b/test/Compat.jl
@@ -10,7 +10,9 @@
             if Setup.devdeps && g == :pyside6
                 # pyside6 is installed as a dev dependency
                 # AND it's a dependency of matplotlib, which is also a dev dependency
-                @test PythonCall.event_loop_on(g) isa Timer
+                # broken on mac - error "ModuleNotFoundError: No module named
+                # 'shiboken6.Shiboken'" when importing pyside6
+                @test PythonCall.event_loop_on(g) isa Timer skip=Sys.isapple()
             else
                 @test_throws PyException PythonCall.event_loop_on(g)
             end


### PR DESCRIPTION
We've started getting the following error during tests on Mac. For now we're just skipping this particular test as broken.

```
PySide6/__init__.py: Unable to import Shiboken from /Users/runner/work/PythonCall.jl/PythonCall.jl/pysrc, /Users/runner/work/PythonCall.jl/PythonCall.jl/test/.CondaPkg/.pixi/envs/default/lib/python314t.zip, /Users/runner/work/PythonCall.jl/PythonCall.jl/test/.CondaPkg/.pixi/envs/default/lib/python3.14t, /Users/runner/work/PythonCall.jl/PythonCall.jl/test/.CondaPkg/.pixi/envs/default/lib/python3.14t/lib-dynload, /Users/runner/work/PythonCall.jl/PythonCall.jl/test/.CondaPkg/.pixi/envs/default/lib/python3.14t/site-packages, /Users/runner/work/PythonCall.jl/PythonCall.jl/test/.CondaPkg/.pixi/envs/default/lib/python3.14/site-packages: No module named 'shiboken6.Shiboken'
  pyside6: Error During Test at /Users/runner/work/PythonCall.jl/PythonCall.jl/test/Compat.jl:13
    Test threw exception
    Expression: PythonCall.event_loop_on(g) isa Timer
    Python: ModuleNotFoundError: No module named 'shiboken6.Shiboken'
    Python stacktrace:
     [1] <module>
       @ ~/work/PythonCall.jl/PythonCall.jl/test/.CondaPkg/.pixi/envs/default/lib/python3.14/site-packages/shiboken6/__init__.py:27
     [2] _setupQtDirectories
       @ ~/work/PythonCall.jl/PythonCall.jl/test/.CondaPkg/.pixi/envs/default/lib/python3.14/site-packages/PySide6/__init__.py:66
     [3] <module>
       @ ~/work/PythonCall.jl/PythonCall.jl/test/.CondaPkg/.pixi/envs/default/lib/python3.14/site-packages/PySide6/__init__.py:143
     [4] new_event_loop_callback
       @ <string>:12
    Stacktrace:
      [1] pythrow()
        @ PythonCall.Core ~/work/PythonCall.jl/PythonCall.jl/src/Core/err.jl:77
      [2] errcheck
        @ ~/work/PythonCall.jl/PythonCall.jl/src/Core/err.jl:10 [inlined]
      [3] pycallargs
        @ ~/work/PythonCall.jl/PythonCall.jl/src/Core/builtins.jl:194 [inlined]
      [4] #pycall#25
        @ ~/work/PythonCall.jl/PythonCall.jl/src/Core/builtins.jl:213 [inlined]
      [5] pycall
        @ ~/work/PythonCall.jl/PythonCall.jl/src/Core/builtins.jl:203 [inlined]
      [6] Py
        @ ~/work/PythonCall.jl/PythonCall.jl/src/Core/Py.jl:357 [inlined]
      [7] event_loop_on(g::Symbol; interval::Float64, fix::Bool)
        @ PythonCall.Compat ~/work/PythonCall.jl/PythonCall.jl/src/Compat/gui.jl:195
      [8] event_loop_on
        @ ~/work/PythonCall.jl/PythonCall.jl/src/Compat/gui.jl:192 [inlined]
      [9] macro expansion
        @ ~/hostedtoolcache/julia/1.12.6/aarch64/share/julia/stdlib/v1.12/Test/src/Test.jl:677 [inlined]
     [10] macro expansion
        @ ~/work/PythonCall.jl/PythonCall.jl/test/Compat.jl:13 [inlined]
     [11] macro expansion
        @ ~/hostedtoolcache/julia/1.12.6/aarch64/share/julia/stdlib/v1.12/Test/src/Test.jl:1866 [inlined]
     [12] macro expansion
        @ ~/work/PythonCall.jl/PythonCall.jl/test/Compat.jl:8 [inlined]
     [13] macro expansion
        @ ~/hostedtoolcache/julia/1.12.6/aarch64/share/julia/stdlib/v1.12/Test/src/Test.jl:1777 [inlined]
     [14] top-level scope
        @ ~/work/PythonCall.jl/PythonCall.jl/test/Compat.jl:8
```

e.g. https://github.com/JuliaPy/PythonCall.jl/actions/runs/31814802346/job/94813795114