### PR TITLE
Add __test__ attribute to AnyValue class for pytest

### DIFF
--- a/src/JlWrap/any.jl
+++ b/src/JlWrap/any.jl
@@ -233,6 +233,7 @@ function init_any()
 $("\n"^(@__LINE__()-1))
 class AnyValue(ValueBase):
     __slots__ = ()
+    __test__ = False  # make pytest not try looking for tests in here
     def __repr__(self):
         if self._jl_isnull():
             return "<jl NULL>"


### PR DESCRIPTION
I don't entirely understand why this happens.
I think it is some interaction between pytest and the python debugger and it not undestanding python code when that code is not in a `.py` file.

But running juliacall in the python debugger, excent with it set to only break on User Uncaught Exceptions  always breaks like 2-5 times in this code, because it tried to check if it has a `__test__` attribute. Which it does not.

Easiest fix is just to add it.
Though it isn't the most satisfying.