### PR TITLE
protect GIL with Julia reentrant mutex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PythonCall"
 uuid = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 authors = ["Christopher Doris <github.com/cjdoris>"]
-version = "0.9.35"
+version = "0.9.36"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"

--- a/src/GIL/GIL.jl
+++ b/src/GIL/GIL.jl
@@ -25,6 +25,12 @@ if Base.VERSION ≥ v"1.11"
     )
 end
 
+const LOCK = ReentrantLock()
+
+function __init__()
+    Base.lock(LOCK)
+    return nothing
+end
 
 """
     lock(f)
@@ -42,11 +48,16 @@ See [`@lock`](@ref) for the macro form.
     This function is experimental. Its semantics may be changed without notice.
 """
 function lock(f)
+    Base.lock(LOCK)
+    task = current_task()
+    sticky, task.sticky = task.sticky, true
     state = C.PyGILState_Ensure()
     try
         f()
     finally
         C.PyGILState_Release(state)
+        task.sticky = sticky
+        Base.unlock(LOCK)
     end
 end
 
@@ -67,11 +78,16 @@ The macro equivalent of [`lock`](@ref).
 """
 macro lock(expr)
     quote
+        Base.lock($LOCK)
+        task = current_task()
+        sticky, task.sticky = task.sticky, true
         state = C.PyGILState_Ensure()
         try
             $(esc(expr))
         finally
             C.PyGILState_Release(state)
+            task.sticky = sticky
+            Base.unlock($LOCK)
         end
     end
 end
@@ -92,11 +108,17 @@ See [`@unlock`](@ref) for the macro form.
     This function is experimental. Its semantics may be changed without notice.
 """
 function unlock(f)
+    if !islocked(LOCK)
+        error("GIL is not held")
+    end
+
+    Base.unlock(LOCK)
     state = C.PyEval_SaveThread()
     try
         f()
     finally
         C.PyEval_RestoreThread(state)
+        Base.lock(LOCK)
     end
 end
 
@@ -117,11 +139,17 @@ The macro equivalent of [`unlock`](@ref).
 """
 macro unlock(expr)
     quote
+        if !islocked($LOCK)
+            error("GIL is not held")
+        end
+
+        Base.unlock($LOCK)
         state = C.PyEval_SaveThread()
         try
             $(esc(expr))
         finally
             C.PyEval_RestoreThread(state)
+            Base.lock($LOCK)
         end
     end
 end


### PR DESCRIPTION
This is an alternative to/elaboration on #810, which uses a ReentrantLock to
prevent `GIL.@lock` and friends from stealing the GIL from other Julia tasks
running on other threads.  The behavior of `PyGILState_Ensure()` is to
immediately change the attached thread state, and it does not block until the
GIL is not locked.  This means that _some_ additional protection is necessary to
prevent multiple julia tasks on different threads from stealing the GIL from
each other leading to UB.

Like #810, it makes the task _sticky_ while the GIL is held.  There isn't really
any sense in which the GIL can be held safely on a non-sticky task, and by
unifying locking the GIL with pinning the locking task to its current thread,
this makes multithreaded code with yield points much safer.

I'm not sure whether we may _also_ want an additional "unsafe" mode without the
reentrant lock/task pinning, although at that point you might as well do the
`PyGILState_` calls directly...

I did not change the behavior of the GC, which is only controlled by the
`PyGILState_Check()` function and doesn't manipulate the GIL itself.  I believe
it's still reasonable, and to the extent that it requires some care to use
correctly, it's not affected by these changes.  However, the GC hook test is
failing and I'm not sure why; when I run it interactively it will _eventually_
run the finalizer and empty the queue; it just doesn't happen on the timeline
that the test expects it.  I've tried adding a yield/timedwait to no avail, so
open for suggestions there.