### PR TITLE
Fix JuliaCall binary-directory discovery for symlinks and wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* Bug fix: JuliaCall initialization when the Julia executable is a symlink or
+  wrapper outside its installation directory.
 * Bug fix: avoid precompilation cache miss when `check_bounds` option set.
 * Bug fix: `juliacall` set the environment variable `JULIA_PYTHONCALL_EXECUTABLE`
   instead of `JULIA_PYTHONCALL_EXE`, so child Julia processes resolved a new

--- a/pysrc/juliacall/__init__.py
+++ b/pysrc/juliacall/__init__.py
@@ -220,16 +220,15 @@ def init():
     if (libpath is not None) and (exepath is None):
         raise Exception("PYTHON_JULIACALL_EXE is required if PYTHON_JULIACALL_LIB is set.")
 
-    # Find the Julia library, if not specified.
-    if libpath is None:
+    # Discover the Julia library and binary directory if either is missing.
+    if libpath is None or bindir is None:
         cmd = [exepath, '--project='+project, '--startup-file=no', '-O0', '--compile=min',
                '-e', 'import Libdl; print(abspath(Libdl.dlpath("libjulia")), "\\0", Sys.BINDIR)']
-        libpath, found_bindir = subprocess.run(cmd, check=True, capture_output=True, encoding='utf8').stdout.split('\0')
-        CONFIG['libpath'] = libpath
+        found_libpath, found_bindir = subprocess.run(cmd, check=True, capture_output=True, encoding='utf8').stdout.split('\0')
+        if libpath is None:
+            CONFIG['libpath'] = libpath = found_libpath
         if bindir is None:
             CONFIG['bindir'] = bindir = found_bindir
-    if bindir is None:
-        bindir = os.path.dirname(exepath)
     assert os.path.exists(libpath)
     assert os.path.exists(bindir)
 

--- a/pytest/test_issue_816.py
+++ b/pytest/test_issue_816.py
@@ -1,0 +1,89 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+_CHILD = r"""
+import os
+from pathlib import Path
+import shlex
+import stat
+
+import juliapkg
+
+juliapkg.resolve()
+real_executable = juliapkg.executable()
+# Populate the normal JuliaPkg project and libjulia cache before changing only
+# the executable result that JuliaCall will see.
+juliapkg.project()
+juliapkg.libjulia()
+
+launcher = Path(os.environ["JULIACALL_TEST_LAUNCHER"])
+mode = os.environ["JULIACALL_TEST_LAUNCHER_MODE"]
+if mode == "symlink":
+    try:
+        launcher.symlink_to(real_executable)
+    except OSError as exc:
+        print(f"symlink unsupported: {exc}")
+        raise SystemExit(77)
+elif mode == "wrapper":
+    launcher.write_text(
+        "#!/bin/sh\nexec " + shlex.quote(real_executable) + ' "$@"\n',
+        encoding="utf-8",
+    )
+    launcher.chmod(launcher.stat().st_mode | stat.S_IXUSR)
+else:
+    raise AssertionError(mode)
+
+juliapkg.executable = lambda: str(launcher)
+
+from juliacall import Main
+
+assert Main.seval("1 + 1") == 2
+"""
+
+
+def _run_launcher_case(
+    tmp_path: Path, mode: str
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for name in (
+        "PYTHON_JULIACALL_EXE",
+        "PYTHON_JULIACALL_PROJECT",
+        "PYTHON_JULIACALL_BINDIR",
+        "PYTHON_JULIACALL_LIB",
+    ):
+        env.pop(name, None)
+    env["PYTHONPATH"] = str(Path(__file__).parents[1] / "pysrc")
+    env["JULIACALL_TEST_LAUNCHER"] = str(
+        tmp_path / "outside-julia-layout" / "julia"
+    )
+    env["JULIACALL_TEST_LAUNCHER_MODE"] = mode
+    Path(env["JULIACALL_TEST_LAUNCHER"]).parent.mkdir()
+    return subprocess.run(
+        [sys.executable, "-c", _CHILD],
+        cwd=Path(__file__).parents[1],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+@pytest.mark.parametrize("mode", ["symlink", "wrapper"])
+def test_issue_816_launcher_outside_julia_bindir(tmp_path, mode):
+    """https://github.com/JuliaPy/PythonCall.jl/issues/816"""
+    if mode == "wrapper" and os.name != "posix":
+        pytest.skip("the executable wrapper requires POSIX sh")
+
+    result = _run_launcher_case(tmp_path, mode)
+    if mode == "symlink" and result.returncode == 77:
+        pytest.skip(result.stdout.strip())
+    assert result.returncode == 0, (
+        f"child exited with {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
Fixes #816.

JuliaCall can locate `libjulia` through JuliaPkg while still deriving the wrong binary directory from the executable path. When that executable is a symlink or wrapper outside the Julia installation, initialization searches for `sys.so` in the wrong location.

Query Julia for `Sys.BINDIR` whenever the binary directory is unknown, preserving any library path or binary directory already supplied. Remove the executable-directory fallback. Using Julia's own directory information also handles wrappers, which resolving symlinks alone would not fix.

This restores a discovery subprocess for default initialization. Configurations where both `libpath` and `bindir` are known still skip that subprocess.

Add subprocess regression tests for a symlink and a POSIX executable wrapper outside the installation directory. Both exercise normal JuliaPkg resolution with its cached library path.

## Validation

The new symlink and wrapper regression tests reproduce the missing `sys.so` failure on unmodified `main` and pass with this patch.

Local Julia-suite validation encounters a GTK3 test failure because GTK is available where the test expects an import exception. The identical failure was reproduced on unmodified `main`.
